### PR TITLE
T343849: SpecialEditCount::getDescription: Return Message instead of string

### DIFF
--- a/src/SpecialEditCount.php
+++ b/src/SpecialEditCount.php
@@ -58,7 +58,7 @@ class SpecialEditCount extends SpecialPage {
 	 * @inheritDoc
 	 */
 	public function getDescription() {
-		return $this->msg( 'editcountneue' )->text();
+		return $this->msg( 'editcountneue' );
 	}
 
 	/**


### PR DESCRIPTION
SpecialEditCount::getDescription: Return Message instead of string

Use of string return from SpecialPage::getDescription() was deprecated in MediaWiki 1.41

https://phabricator.wikimedia.org/T343849

Bugs:
* [T343849](https://phabricator.wikimedia.org/T343849)
* #25